### PR TITLE
Fix additional deprecation warnings from Pandas

### DIFF
--- a/autorank/_util.py
+++ b/autorank/_util.py
@@ -426,7 +426,7 @@ def get_sorted_rank_groups(result, reverse):
             critical_difference = result.cd
         else:
             sorted_ranks = result.rankdf['mean']
-            critical_difference = (result.rankdf.ci_upper[0] - result.rankdf.ci_lower[0]) / 2
+            critical_difference = (result.rankdf.ci_upper.iloc[0] - result.rankdf.ci_lower.iloc[0]) / 2
 
     groups = []
     cur_max_j = -1
@@ -574,7 +574,7 @@ def ci_plot(result, reverse, ax, width):
         fig = plt.figure(figsize=(width, height))
         fig.set_facecolor('white')
         ax = plt.gca()
-    ax.errorbar(sorted_means, range(len(sorted_means)), xerr=(ci_upper[0] - ci_lower[0]) / 2, marker='o',
+    ax.errorbar(sorted_means, range(len(sorted_means)), xerr=(ci_upper.iloc[0] - ci_lower.iloc[0]) / 2, marker='o',
                 linestyle='None', color='k', ecolor='k')
     ax.set_yticks(range(len(names)))
     ax.set_yticklabels(names.to_list())

--- a/autorank/autorank.py
+++ b/autorank/autorank.py
@@ -549,7 +549,7 @@ def create_report(result, *, decimal_places=3):
                       % (decimal_places, result.pvalue,
                          create_population_string(result.rankdf.index, with_stats=True),
                          result.rankdf.index[larger], result.rankdf.index[smaller],
-                         result.rankdf.magnitude[larger], effect_size, decimal_places, result.rankdf.effect_size[larger]))
+                         result.rankdf.magnitude.iloc[larger], effect_size, decimal_places, result.rankdf.effect_size.iloc[larger]))
         elif result.omnibus == 'wilcoxon':
             larger = np.argmax(result.rankdf['median'].values)
             smaller = int(bool(larger - 1))
@@ -583,7 +583,7 @@ def create_report(result, *, decimal_places=3):
                          create_population_string(result.rankdf.index[larger], with_stats=True),
                          create_population_string(result.rankdf.index[smaller], with_stats=True),
                          result.rankdf.index[larger], result.rankdf.index[smaller],
-                         result.rankdf.magnitude[larger], effect_size, decimal_places, result.rankdf.effect_size[larger]))
+                         result.rankdf.magnitude.iloc[larger], effect_size, decimal_places, result.rankdf.effect_size.iloc[larger]))
         else:
             raise ValueError('Unknown omnibus test for difference in the central tendency: %s' % result.omnibus)
     else:


### PR DESCRIPTION
This is a follow-up for #28.

I missed some warnings in the previous PR, this time I used the unit tests as a reference to have more confidence all the warnings are caught.