### PR TITLE
Fix typos

### DIFF
--- a/autorank/_util.py
+++ b/autorank/_util.py
@@ -108,7 +108,7 @@ def _cohen_d(x, y):
 def _akinshin_gamma(x, y):
     """
     Calculate the effect size using a non-parametric variant of Cohen's d that replaces the pooled
-    standard deviation with the pooled median absolute devision. This metric is based on this blog
+    standard deviation with the pooled median absolute deviation. This metric is based on this blog
     post (no publication yet).
     https://aakinshin.net/posts/nonparametric-effect-size/
     """

--- a/autorank/autorank.py
+++ b/autorank/autorank.py
@@ -699,7 +699,7 @@ def create_report(result, *, decimal_places=3):
                       "(p=%.*f) that the data is homoscedastic. Thus, we assume that our data is "
                       "homoscedastic." % (decimal_places, result.pval_homogeneity))
             else:
-                print("We applied Bartlett's test for homogeneity and reject the null hypothesis (p=%.*f) that the"
+                print("We applied Bartlett's test for homogeneity and reject the null hypothesis (p=%.*f) that the "
                       "data is homoscedastic. Thus, we assume that our data is "
                       "heteroscedastic." % (decimal_places, result.pval_homogeneity))
 

--- a/autorank/autorank.py
+++ b/autorank/autorank.py
@@ -121,7 +121,7 @@ def autorank(data, alpha=0.05, verbose=False, order='descending', approach='freq
         _(New in Version 1.2.0)_
 
     plot_order (list):
-        List with the order of the populations used for ploting, where reasonable (e.g., CI plots). If this is not none, this overrides the order parameter for visualizations. 
+        List with the order of the populations used for plotting, where reasonable (e.g., CI plots). If this is not none, this overrides the order parameter for visualizations.
         _(New in Version 1.3.0)_
 
     # Returns
@@ -383,7 +383,7 @@ def plot_stats(result, *, allow_insignificant=False, ax=None, width=None):
         raise TypeError("result must be of type RankResult and should be the outcome of calling the autorank function.")
 
     if result.omnibus == 'bayes':
-        raise ValueError("ploting results of bayesian analysis not yet supported.")
+        raise ValueError("plotting results of bayesian analysis not yet supported.")
 
     if result.pvalue >= result.alpha and not allow_insignificant:
         raise ValueError(


### PR DESCRIPTION
In `create_report` (line 702 of `autorank.py`), a space was missing at the end of a line, causing two words to merge.

I also fixed a few misspelt words I found.