### PR TITLE
Remove an extra print call

### DIFF
--- a/autorank/_util.py
+++ b/autorank/_util.py
@@ -430,8 +430,6 @@ def _create_result_df_skeleton(data, alpha, all_normal, order, order_column='mea
             rankdf.at[population, 'ci_upper'] = upper
         population_above = population
 
-    print(rankdf)
-
     return rankdf, effsize_method, reorder_pos
 
 


### PR DESCRIPTION
In commit 3100e29, an extra `print` call was inserted at the end of `_create_result_df_skeleton`, probably a leftover from a prototype.

This extra statement caused the rankdf data frame to be printed with each call of the `autorank` main function, even with verbose mode off.

The deletion of the call restores the behaviour of version 1.2.