### PR TITLE
docs: fix autorank rope default

### DIFF
--- a/autorank/autorank.py
+++ b/autorank/autorank.py
@@ -84,7 +84,7 @@ def autorank(data, alpha=0.05, verbose=False, order='descending', approach='freq
         ANOVA+Tukey's HSD, or Friedman+Nemenyi). With 'bayesian', the Bayesian signed ranked test is used.
         _(New in Version 1.1.0)_
 
-    rope (float, default=0.01):
+    rope (float, default=0.1):
         Region of Practical Equivalence (ROPE) used for the bayesian analysis. The statistical analysis assumes that
         differences from the central tendency that are within the ROPE do not matter in practice. Therefore, such
         deviations may be considered to be equivalent. The ROPE is defined as an interval around the central tendency


### PR DESCRIPTION
Summary
- Update the `autorank()` `rope` parameter docs to list the actual default, `0.1`.
- Align the API docstring with the function signature and README Bayesian ROPE explanation.

Validation
- `python3 - <<PY ... PY` AST check confirmed the `rope` signature default and docstring both use `0.1`.
- `python3 -m py_compile autorank/autorank.py autorank/_util.py autorank/__init__.py tests/test_autorank.py`
- `git diff --check`

I also tried `python3 -m unittest tests.test_autorank.TestAutorank.test_autorank_ropezero -v`, but the local environment is missing `matplotlib`. This PR changes only documentation text and does not change runtime behavior.

Fixes #47